### PR TITLE
fix: don't document globally enabled rules as disabled by file-scoped overrides

### DIFF
--- a/lib/plugin-config-resolution.ts
+++ b/lib/plugin-config-resolution.ts
@@ -32,6 +32,10 @@ async function resolvePotentiallyFlatConfigs(
 
   if (Array.isArray(potentiallyFlatConfigs)) {
     for (const config of potentiallyFlatConfigs) {
+      if (isFileScopedFlatConfig(config)) {
+        continue;
+      }
+
       Object.assign(rules, await resolvePotentiallyFlatConfigs(config));
     }
   } else {
@@ -39,6 +43,14 @@ async function resolvePotentiallyFlatConfigs(
   }
 
   return rules;
+}
+
+function isFileScopedFlatConfig(
+  config: TSESLint.Linter.ConfigType,
+): config is FlatConfig.Config {
+  return (
+    !Array.isArray(config) && 'files' in config && config.files !== undefined
+  );
 }
 
 /**

--- a/lib/plugin-config-resolution.ts
+++ b/lib/plugin-config-resolution.ts
@@ -28,28 +28,36 @@ export async function resolveConfigsToRules(
 async function resolvePotentiallyFlatConfigs(
   potentiallyFlatConfigs: TSESLint.Linter.ConfigType,
 ): Promise<Rules> {
-  const rules: Rules = {};
+  const scopedRules: Rules = {};
+  const unscopedRules: Rules = {};
 
-  if (Array.isArray(potentiallyFlatConfigs)) {
-    for (const config of potentiallyFlatConfigs) {
-      if (isFileScopedFlatConfig(config)) {
-        continue;
+  async function mergeConfigs(
+    configs: TSESLint.Linter.ConfigType,
+  ): Promise<void> {
+    if (Array.isArray(configs)) {
+      for (const config of configs) {
+        await mergeConfigs(config);
       }
-
-      Object.assign(rules, await resolvePotentiallyFlatConfigs(config));
+    } else {
+      Object.assign(
+        isScopedFlatConfig(configs) ? scopedRules : unscopedRules,
+        await resolveConfigRules(configs),
+      );
     }
-  } else {
-    Object.assign(rules, await resolveConfigRules(potentiallyFlatConfigs));
   }
 
-  return rules;
+  await mergeConfigs(potentiallyFlatConfigs);
+
+  return { ...scopedRules, ...unscopedRules };
 }
 
-function isFileScopedFlatConfig(
+function isScopedFlatConfig(
   config: TSESLint.Linter.ConfigType,
 ): config is FlatConfig.Config {
   return (
-    !Array.isArray(config) && 'files' in config && config.files !== undefined
+    !Array.isArray(config) &&
+    (('files' in config && config.files !== undefined) ||
+      ('ignores' in config && config.ignores !== undefined))
   );
 }
 

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -36,6 +36,30 @@ exports[`generate (configs) > config as flat config > updates the documentation 
 "
 `;
 
+exports[`generate (configs) > config as flat config with file-scoped overrides > does not treat file-scoped overrides as global config severity 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (configs) > config as flat config with file-scoped overrides > does not treat file-scoped overrides as global config severity 2`] = `
+"# test/no-foo
+
+📝 Description of no-foo.
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generate (configs) > config with overrides > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -60,6 +60,30 @@ exports[`generate (configs) > config as flat config with file-scoped overrides >
 "
 `;
 
+exports[`generate (configs) > config as flat config with only scoped entries > uses the last scoped severity 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (configs) > config as flat config with only scoped entries > uses the last scoped severity 2`] = `
+"# test/no-foo
+
+📝 Description of no-foo.
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generate (configs) > config with overrides > generates the documentation 1`] = `
 "## Rules
 <!-- begin auto-generated rules list -->

--- a/test/lib/generate/__snapshots__/configs-test.ts.snap
+++ b/test/lib/generate/__snapshots__/configs-test.ts.snap
@@ -1,5 +1,53 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`generate (configs) > config as a nested flat config array > flattens nested arrays before separating scoped from unscoped 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (configs) > config as a nested flat config array > flattens nested arrays before separating scoped from unscoped 2`] = `
+"# test/no-foo
+
+📝 Description of no-foo.
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (configs) > config as a single scoped flat config object > keeps a rule that is only configured by a scoped object 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (configs) > config as a single scoped flat config object > keeps a rule that is only configured by a scoped object 2`] = `
+"# test/no-foo
+
+📝 Description of no-foo.
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
 exports[`generate (configs) > config as flat config > updates the documentation 1`] = `
 "<!-- begin auto-generated rules list -->
 
@@ -29,6 +77,67 @@ exports[`generate (configs) > config as flat config > updates the documentation 
 "# test/no-bar
 
 📝 Description of no-bar.
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (configs) > config as flat config mixing scoped and unscoped rules > prefers the unscoped severity per rule and keeps scoped-only rules 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+⚠️ Configurations set to warn in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 | ⚠️ |
+| :----------------------------- | :--------------------- | :- | :- |
+| [no-bar](docs/rules/no-bar.md) | Description of no-bar. | ✅  |    |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. |    | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (configs) > config as flat config mixing scoped and unscoped rules > prefers the unscoped severity per rule and keeps scoped-only rules 2`] = `
+"# test/no-foo
+
+📝 Description of no-foo.
+
+⚠️ This rule _warns_ in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (configs) > config as flat config mixing scoped and unscoped rules > prefers the unscoped severity per rule and keeps scoped-only rules 3`] = `
+"# test/no-bar
+
+📝 Description of no-bar.
+
+💼 This rule is enabled in the ✅ \`recommended\` config.
+
+<!-- end auto-generated rule header -->
+"
+`;
+
+exports[`generate (configs) > config as flat config with an ignores-scoped override > does not treat an ignores-scoped override as global config severity 1`] = `
+"<!-- begin auto-generated rules list -->
+
+💼 Configurations enabled in.\\
+✅ Set in the \`recommended\` configuration.
+
+| Name                           | Description            | 💼 |
+| :----------------------------- | :--------------------- | :- |
+| [no-foo](docs/rules/no-foo.md) | Description of no-foo. | ✅  |
+
+<!-- end auto-generated rules list -->"
+`;
+
+exports[`generate (configs) > config as flat config with an ignores-scoped override > does not treat an ignores-scoped override as global config severity 2`] = `
+"# test/no-foo
+
+📝 Description of no-foo.
 
 💼 This rule is enabled in the ✅ \`recommended\` config.
 

--- a/test/lib/generate/configs-test.ts
+++ b/test/lib/generate/configs-test.ts
@@ -529,4 +529,56 @@ describe('generate (configs)', () => {
       expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
     });
   });
+
+  describe('config as flat config with only scoped entries', () => {
+    let fixture: FixtureContext;
+
+    beforeAll(async () => {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {},
+              },
+            },
+            configs: {
+              recommended: [
+                {
+                  files: ['**/*.js'],
+                  rules: {
+                    'test/no-foo': 'warn',
+                  }
+                },
+                {
+                  ignores: ['**/*.test.js'],
+                  rules: {
+                    'test/no-foo': 'error',
+                  }
+                }
+              ]
+            }
+          };`,
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+          'docs/rules/no-foo.md': '',
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await fixture.cleanup();
+    });
+
+    it('uses the last scoped severity', async () => {
+      await generate(fixture.path);
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+
+      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+    });
+  });
 });

--- a/test/lib/generate/configs-test.ts
+++ b/test/lib/generate/configs-test.ts
@@ -478,4 +478,55 @@ describe('generate (configs)', () => {
       expect(await fixture.readFile('docs/rules/no-bar.md')).toMatchSnapshot();
     });
   });
+
+  describe('config as flat config with file-scoped overrides', () => {
+    let fixture: FixtureContext;
+
+    beforeAll(async () => {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {},
+              },
+            },
+            configs: {
+              recommended: [
+                {
+                  rules: {
+                    'test/no-foo': 'error',
+                  }
+                },
+                {
+                  files: ['**/*.js'],
+                  rules: {
+                    'test/no-foo': 'off',
+                  }
+                }
+              ]
+            }
+          };`,
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+          'docs/rules/no-foo.md': '',
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await fixture.cleanup();
+    });
+
+    it('does not treat file-scoped overrides as global config severity', async () => {
+      await generate(fixture.path);
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+
+      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+    });
+  });
 });

--- a/test/lib/generate/configs-test.ts
+++ b/test/lib/generate/configs-test.ts
@@ -581,4 +581,211 @@ describe('generate (configs)', () => {
       expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
     });
   });
+
+  describe('config as flat config with an ignores-scoped override', () => {
+    let fixture: FixtureContext;
+
+    beforeAll(async () => {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {},
+              },
+            },
+            configs: {
+              recommended: [
+                {
+                  rules: {
+                    'test/no-foo': 'error',
+                  }
+                },
+                {
+                  ignores: ['**/*.js'],
+                  rules: {
+                    'test/no-foo': 'off',
+                  }
+                }
+              ]
+            }
+          };`,
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+          'docs/rules/no-foo.md': '',
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await fixture.cleanup();
+    });
+
+    it('does not treat an ignores-scoped override as global config severity', async () => {
+      await generate(fixture.path);
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+
+      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+    });
+  });
+
+  describe('config as flat config mixing scoped and unscoped rules', () => {
+    let fixture: FixtureContext;
+
+    beforeAll(async () => {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {},
+              },
+              'no-bar': {
+                meta: { docs: { description: 'Description of no-bar.' }, },
+                create(context) {},
+              },
+            },
+            configs: {
+              recommended: [
+                {
+                  files: ['**/*.js'],
+                  rules: {
+                    'test/no-foo': 'error',
+                    'test/no-bar': 'error',
+                  }
+                },
+                {
+                  rules: {
+                    'test/no-foo': 'warn',
+                  }
+                }
+              ]
+            }
+          };`,
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+          'docs/rules/no-foo.md': '',
+          'docs/rules/no-bar.md': '',
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await fixture.cleanup();
+    });
+
+    it('prefers the unscoped severity per rule and keeps scoped-only rules', async () => {
+      await generate(fixture.path);
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+
+      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+
+      expect(await fixture.readFile('docs/rules/no-bar.md')).toMatchSnapshot();
+    });
+  });
+
+  describe('config as a single scoped flat config object', () => {
+    let fixture: FixtureContext;
+
+    beforeAll(async () => {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {},
+              },
+            },
+            configs: {
+              recommended: {
+                files: ['**/*.ts'],
+                rules: {
+                  'test/no-foo': 'error',
+                }
+              }
+            }
+          };`,
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+          'docs/rules/no-foo.md': '',
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await fixture.cleanup();
+    });
+
+    it('keeps a rule that is only configured by a scoped object', async () => {
+      await generate(fixture.path);
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+
+      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+    });
+  });
+
+  describe('config as a nested flat config array', () => {
+    let fixture: FixtureContext;
+
+    beforeAll(async () => {
+      fixture = await setupFixture({
+        fixture: 'esm-base',
+        overrides: {
+          'index.js': `
+          export default {
+            rules: {
+              'no-foo': {
+                meta: { docs: { description: 'Description of no-foo.' }, },
+                create(context) {},
+              },
+            },
+            configs: {
+              recommended: [
+                {
+                  rules: {
+                    'test/no-foo': 'error',
+                  }
+                },
+                [
+                  {
+                    files: ['**/*.js'],
+                    rules: {
+                      'test/no-foo': 'off',
+                    }
+                  }
+                ]
+              ]
+            }
+          };`,
+          'README.md':
+            '<!-- begin auto-generated rules list --><!-- end auto-generated rules list -->',
+          'docs/rules/no-foo.md': '',
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await fixture.cleanup();
+    });
+
+    it('flattens nested arrays before separating scoped from unscoped', async () => {
+      await generate(fixture.path);
+
+      expect(await fixture.readFile('README.md')).toMatchSnapshot();
+
+      expect(await fixture.readFile('docs/rules/no-foo.md')).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
Fixes #822

### Problem

A rule enabled globally in a flat config was reported as disabled when a later file-scoped entry turned it off:

```js
configs: {
  recommended: [
    { rules: { 'test/no-foo': 'error' } },
    { files: ['**/*.js'], rules: { 'test/no-foo': 'off' } },
  ],
}
```

The entries were merged with plain last-wins, so the scoped `off` overwrote the global `error` and the rule dropped out of the readme list and its doc notice.

### Approach

Severities are now resolved per rule:

- prefer the last **unscoped** flat-config severity
- fall back to the last **scoped** severity when a rule has no unscoped setting, which preserves today's behaviour for scoped-only configs
- treat both `files` and `ignores` as scope, per the [configuration files docs](https://eslint.org/docs/latest/use/configure/configuration-files)

Entries are flattened into two buckets before merging, so nested arrays resolve the same way as flat ones.

Scoped entries are not skipped outright. A config like typescript-eslint's `{ files: ['**/*.ts'], rules: { 'plugin/rule': 'error' } }` still reports the rule as enabled, since the rule has no unscoped severity to prefer.

Classic `overrides` last-wins is unchanged, and file-specific notices are left for a follow-up.

### Testing

Six fixtures in `configs-test.ts` cover the merge:

| Config | Expected |
| --- | --- |
| global `error`, then `files`-scoped `off` | still enabled (#822) |
| global `error`, then `ignores`-scoped `off` | still enabled (`ignores` twin) |
| scoped-only, two entries | last scoped severity wins |
| scoped `{a: error, b: error}`, then unscoped `{a: warn}` | `a` warns, `b` stays enabled |
| single scoped object, not in an array | still enabled |
| nested array with a scoped `off` inside | still enabled |

Reverting `lib/plugin-config-resolution.ts` while keeping the fixtures fails three of them (the two `files`/`ignores` cases and the nested-array one). The other three pin behaviour that already held, so they are regression guards rather than demonstrations of the bug.

Full suite passes at 379 tests, and `eslint` is clean on the changed files.
